### PR TITLE
Add custom timestamp support.

### DIFF
--- a/heka/client.py
+++ b/heka/client.py
@@ -236,13 +236,13 @@ class HekaClient(object):
         :param payload: Actual message contents.
         :param fields: Arbitrary key/value pairs for add'l metadata.
         :param timestamp: Custom timestamp for the message. If no timestamp
-                          is given, then it will be the current time.
+                          is given, then current time will be used.
 
         """
         logger = logger if logger is not None else self.logger
         severity = severity if severity is not None else self.severity
         fields = fields if fields is not None else dict()
-        timestamp = time.mktime(timestamp.utctimetuple()) \
+        timestamp = time.mktime(timestamp.timetuple()) \
             if isinstance(timestamp, datetime.datetime) else timestamp
 
         msg = Message()

--- a/heka/client.py
+++ b/heka/client.py
@@ -24,6 +24,7 @@ import time
 import traceback
 import types
 import uuid
+import datetime
 
 from heka.senders import NoSendSender
 from heka.message_pb2 import Message, Field
@@ -223,7 +224,7 @@ class HekaClient(object):
         setattr(self, name, meth)
 
     def heka(self, type, logger=None, severity=None, payload='',
-             fields=None):
+             fields=None, timestamp=None):
         """Create a single message and pass it to the sender for
         delivery.
 
@@ -234,14 +235,18 @@ class HekaClient(object):
                          5424.
         :param payload: Actual message contents.
         :param fields: Arbitrary key/value pairs for add'l metadata.
+        :param timestamp: Custom timestamp for the message. If no timestamp
+                          is given, then it will be the current time.
 
         """
         logger = logger if logger is not None else self.logger
         severity = severity if severity is not None else self.severity
         fields = fields if fields is not None else dict()
+        timestamp = time.mktime(timestamp.utctimetuple()) \
+            if isinstance(timestamp, datetime.datetime) else timestamp
 
         msg = Message()
-        msg.timestamp = int(time.time() * 1000000000)
+        msg.timestamp = int((timestamp or time.time()) * 1000000000)
         msg.type = type
         msg.logger = logger
         msg.severity = severity

--- a/heka/tests/test_client.py
+++ b/heka/tests/test_client.py
@@ -33,6 +33,7 @@ import socket
 import sys
 import threading
 import time
+import datetime
 
 try:
     import simplejson as json
@@ -120,6 +121,25 @@ class TestHekaClient(object):
         del expected_dict['uuid']
         del actual_dict['uuid']
         eq_(actual_dict, expected_dict)
+
+    def test_heka_timestamp(self):
+        payload = 'this is a timestamp test'
+
+        timestamp = time.time()
+
+        msgtype = 'testtype'
+        self.client.heka(msgtype, payload=payload, timestamp=timestamp)
+
+        full_msg = self._extract_full_msg()
+
+        eq_(full_msg.timestamp, timestamp * 1000000000)
+
+        timestamp = datetime.datetime.now()
+        self.client.heka(msgtype, payload=payload, timestamp=timestamp)
+
+        full_msg = self._extract_full_msg()
+
+        eq_(full_msg.timestamp, time.mktime(timestamp.timetuple()) * 1000000000)
 
     def test_oldstyle(self):
         payload = 'debug message'


### PR DESCRIPTION
I wanted to feed some old data into elasticsearch through heka and found that the timestamp has been set to use the current time the message got generated. I added a timestamp param to the heka function to support custom timestamp.
