### PR TITLE
Features/better stdlib logging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+0.30.3 - 2013-11-20
+===================
+- removal of some debug code that was left in heka-py
+- modified the StdlibPayloadEncoder for stdlib logging so that
+  the message type is prefixed to the payload. This lets you
+  differentiate counters, timers and other kinds of messages.
+
 0.30.2 - 2013-09-23
 ===================
 - ProtocolBuffer support matches hekad 0.4.0

--- a/HekaPy.spec
+++ b/HekaPy.spec
@@ -1,6 +1,6 @@
 %define name heka-py
 %define pythonname HekaPy
-%define version 0.30.2
+%define version 0.30.3
 %define unmangled_version %{version}
 %define release 0
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ copyright = u'2012, Mozilla Services'
 # built documents.
 #
 # The short X.Y version.
-version = '0.30.2'
+version = '0.30.3'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/heka/encoders.py
+++ b/heka/encoders.py
@@ -119,7 +119,7 @@ class StdlibPayloadEncoder(BaseEncoder):
             f.value_integer.append(log_level)
 
         data = msg.payload
-        return pack('B', log_level) + data
+        return pack('B10s', log_level, msg.type[:10] + (" "*(10-len(msg.type)))) + data
 
     def decode(self, bytes):
         """

--- a/heka/encoders.py
+++ b/heka/encoders.py
@@ -24,7 +24,6 @@ from heka.message import InvalidMessage
 from heka.message import first_value
 
 from struct import pack
-import base64
 import hmac
 import logging
 
@@ -55,6 +54,7 @@ PB_FIELDMAP = {0: 'value_string',
 class NullEncoder(object):
     def __init__(self, hmc):
         pass
+
     def encode(self, msg):
         return msg
 
@@ -65,8 +65,6 @@ class BaseEncoder(object):
         header.hmac_key_version = hmc['key_version']
         header.hmac_hash_function = HmacHashFunc.Value(hmc['hash_function'])
         hash_func = HASHNAME_TO_FUNC[hmc['hash_function']]
-        print "Hashing with %d bytes as payload" % len(payload)
-        print "Hashing with [%s] bytes as payload" % ":".join(["%02x" % ord(c) for c in payload])
         header.hmac = hmac.new(hmc['key'], payload, hash_func).digest()
 
     def encode(self, msg):
@@ -83,13 +81,11 @@ class BaseEncoder(object):
 
         header_data = h.SerializeToString()
         header_size = len(header_data)
-        print "Header serialize to String len: %d" % len(header_data)
 
         if header_size > MAX_HEADER_SIZE:
             raise InvalidMessage("Header is too long")
 
         pack_fmt = "!bb%dsb%ds" % (header_size, len(payload))
-        print "Pack format: [%s]" % pack_fmt
         byte_data = pack(pack_fmt,
                          RECORD_SEPARATOR,
                          header_size,
@@ -103,7 +99,7 @@ class StdlibPayloadEncoder(BaseEncoder):
     """
     If an incoming message does not have a 'loglevel' set,
     we just use a default of logging.INFO
-    """ 
+    """
     def __init__(self, hmc=None):
         self.hmc = hmc
 

--- a/heka/streams/logging.py
+++ b/heka/streams/logging.py
@@ -20,12 +20,8 @@ Allows heka code to generate output using Python's standard library's
 """
 from __future__ import absolute_import
 
-from heka.client import SEVERITY
-from heka.util import json
-
 import logging
 import struct
-
 
 
 class StdLibLoggingStream(object):
@@ -48,10 +44,10 @@ class StdLibLoggingStream(object):
 
     def write(self, msg):
         # The first byte is always the stdlib logging severity
-        # level. 
-        log_struct, actual_msg = msg[0], msg[1:]
+        # level.
+        log_struct, msg_type, actual_msg = msg[0], msg[1:11].strip(), msg[11:]
         log_level = struct.unpack('B', log_struct)[0]
-        self.logger.log(log_level, actual_msg)
+        self.logger.log(log_level, "%s: %s" % (msg_type, actual_msg))
 
     def flush(self):
         pass

--- a/heka/tests/test_client.py
+++ b/heka/tests/test_client.py
@@ -286,7 +286,7 @@ class TestStdLogging(object):
             ok_(mock_log.call_count == 1)
 
             log_level, call_data = mock_log.call_args[0]
-            eq_(call_data, 'this is some text')
+            eq_(call_data, 'stdlog: this is some text')
             eq_(log_level, logging.INFO)
 
 

--- a/heka/tests/test_logging.py
+++ b/heka/tests/test_logging.py
@@ -13,12 +13,12 @@
 # ***** END LICENSE BLOCK *****
 from __future__ import absolute_import
 from heka.client import HekaClient
-from heka.encoders import ProtobufEncoder
 from heka.logging import hook_logger
 from mock import Mock
 from nose.tools import eq_
 import logging
 from heka.tests.helpers import decode_message
+
 
 class TestLoggingHook(object):
     logger = 'tests'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.30.2'
+version = '0.30.3'
 
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.rst')) as f:


### PR DESCRIPTION
Minor updates to heka-py to make it possible to verify the message type when using the StdlibLogging output.

This is necessary to verify that heka integration is correct in mozilla/zamboni.
