### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: python
 python:
  - "2.6"
  - "2.7"
+ - "3.3"
 install: pip install -r required.txt -r optional.txt --use-mirrors
 script: nosetests


### PR DESCRIPTION
I see that the build process does not include Python 3.
I added Python 3.3 to the build process (3.4 will be added when https://github.com/travis-ci/travis-ci/issues/1989 is resolved).
We'll start there and see what else there is to adjust.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla-services/heka-py/21)

<!-- Reviewable:end -->
